### PR TITLE
For git, also find untracked, non-ignored files.

### DIFF
--- a/find-file-in-repository.el
+++ b/find-file-in-repository.el
@@ -113,7 +113,8 @@
 
 (defvar ffir-repository-types
   `((".git"   . ,(lambda (dir)
-                   (ffir-shell-command "git ls-files -z"       "\0" dir)))
+                   (ffir-shell-command
+                    "git ls-files -zco --exclude-standard"     "\0" dir)))
     (".hg"    . ,(lambda (dir)
                    (ffir-shell-command "hg locate -0"          "\0" dir)))
     ("_darcs" . ,(lambda (dir)


### PR DESCRIPTION
I'm not sure this is in line with your vision for the project, nor am I sure how to make the other supported VCSes act similarly, but for git I've found it useful for ffir to also show new, untracked, but non-ignored files.
