### PR TITLE
Fix C-j behaviour

### DIFF
--- a/find-file-in-repository.el
+++ b/find-file-in-repository.el
@@ -144,10 +144,11 @@
   "Actually find file to open, using ido."
   (add-hook 'ido-setup-hook 'ffir-ido-setup)
   (unwind-protect
-      (let ((file (ido-completing-read "Find file in repository: "
-                                       (mapcar 'car file-list))))
+      (let* ((file (ido-completing-read "Find file in repository: "
+                                        (mapcar 'car file-list)))
+             (path (or (cdr (assoc file file-list)) file)))
         (cond
-         (file (find-file (cdr (assoc file file-list))))
+         (file (find-file path))
          ((eq ido-exit 'fallback) (ido-find-file))))
     (remove-hook 'ido-setup-hook 'ffir-ido-setup)))
 


### PR DESCRIPTION
In ido-mode C-j is bound to `ido-select-text`, which will open a new
buffer if a buffer with the given name does not exist.

Previously `ffir-ido-find-file` would call `find-file` with `nil` as the
argument if file was not found in file-list. This would result in an
error.

To reproduce:
1) Open a file in a repository
2) Run `find-file-in-repository`
3) Type the name of file that does not exist (e.g. `test`)
4) Press `C-j`

The following message appears in the minibuffer and Messages buffer:
`find-file-noselect: Wrong type argument: stringp, nil`

This PR fixes the issue by just passing the plain filename to find-file in case it's not found in file-list, which seems to work OK. This behaviour should be indentical to `ido-find-file`.
