### PR TITLE
Pass --recursive to bzr

### DIFF
--- a/find-file-in-repository.el
+++ b/find-file-in-repository.el
@@ -120,7 +120,8 @@
     ("_darcs" . ,(lambda (dir)
                    (ffir-shell-command "darcs show files -0"   "\0" dir)))
     (".bzr"   . ,(lambda (dir)
-                   (ffir-shell-command "bzr ls --versioned -0" "\0" dir)))
+                   (ffir-shell-command
+                    "bzr ls --versioned --recursive -0"        "\0" dir)))
     ("_MTN"   . ,(lambda (dir)
                    (ffir-shell-command "mtn list known"        "\n" dir)))
 


### PR DESCRIPTION
Without this flag, bzr does not list the contents of subdirectories, only the top-level directory.
