### PR TITLE
Add ivy support

### DIFF
--- a/find-file-in-repository.el
+++ b/find-file-in-repository.el
@@ -37,6 +37,10 @@
 ;; This library currently has support for:
 ;;     git, mercurial, darcs, bazaar, monotone, svn
 ;;
+;; By default ido completion is used if ido is enabled. Completion
+;; method can be customized via `ffir-completion' variable. Possible
+;; values are nil (default), 'find-file, 'ido and 'ivy.
+;;
 ;; Contributions for support of other repository types are welcome.
 ;; Please send a pull request to
 ;; https://github.com/hoffstaetter/find-file-in-repository and I will
@@ -46,6 +50,15 @@
 ;;    (global-set-key (kbd "C-x f") 'find-file-in-repository)
 
 ;;; Code:
+
+(defgroup find-file-in-repository nil
+  "Find file in repository."
+  :group 'convenience)
+
+(defcustom ffir-completion nil
+  "Completion framework. Options are nil, find-file, ido and ivy."
+  :type 'symbol
+  :group 'find-file-in-repository)
 
 (defun ffir-system-is-windows()
   (or (string-equal system-type "windows-nt")
@@ -151,6 +164,23 @@
   (define-key ido-completion-map (kbd "C-x C-f") 'ido-fallback-command)
   (define-key ido-completion-map (kbd "C-x f") 'ido-fallback-command))
 
+(defun ffip-ivy-fallback-command ()
+  (interactive)
+  (ivy-quit-and-run (command-execute (ffir-default-find-file-command))))
+
+(defun ffir-ivy-make-keymap ()
+  "Create a map with fallback bindings to ido keymap while ffir is active."
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-x C-f") 'ffip-ivy-fallback-command)
+    (define-key map (kbd "C-x f") 'ffip-ivy-fallback-command)
+    map))
+
+(defun ffir-find-file (file-list)
+  "Actually find file to open, using completing-read."
+  (let ((file (completing-read "Find file in repository: "
+                        (mapcar 'car file-list))))
+    (find-file (cdr (assoc file file-list)))))
+
 (defun ffir-ido-find-file (file-list)
   "Actually find file to open, using ido."
   (add-hook 'ido-setup-hook 'ffir-ido-setup)
@@ -163,11 +193,28 @@
          ((eq ido-exit 'fallback) (ido-find-file))))
     (remove-hook 'ido-setup-hook 'ffir-ido-setup)))
 
-(defun ffir-find-file (file-list)
-  "Actually find file to open, without using ido."
-  (let ((file (completing-read "Find file in repository: "
-                               (mapcar 'car file-list))))
-    (find-file (cdr (assoc file file-list)))))
+(defun ffir-ivy-find-file (file-list)
+  "Actually find file to open, using ivy."
+  (let* ((file (ivy-read "Find file in repository: "
+                         (mapcar 'car file-list)
+                         :keymap (ffir-ivy-make-keymap)))
+               (path (or (cdr (assoc file file-list)) file)))
+         (when file (find-file path))))
+
+(defun ffir-default-find-file (file-list)
+  "Actually find file to open, taking into account ffir-completion."
+  (let ((find-file
+         (cond ((eq ffir-completion 'find-file) 'ffir-find-file)
+               ((eq ffir-completion 'ido) 'ffir-ido-find-file)
+               ((eq ffir-completion 'ivy) 'ffir-ivy-find-file)
+               ((if (and (boundp 'ido-mode) ido-mode)
+                    'ffir-ido-find-file 'ffir-find-file)))))
+    (funcall find-file file-list)))
+
+(defun ffir-default-find-file-command ()
+  (cond ((eq ffir-completion 'find-file) 'find-file)
+        ((eq ffir-completion 'ido) 'ido-find-file)
+        ((if (and (boundp 'ido-mode) ido-mode) 'ido-find-file 'find-file))))
 
 ;;;###autoload
 (defun find-file-in-repository ()
@@ -193,11 +240,9 @@
                (file-list (funcall (ffir-directory-contains-which-file
                                     ffir-repository-types repo-directory)
                                    repo-directory)))
-          (funcall (ffir-when-ido 'ffir-ido-find-file 'ffir-find-file)
-                   file-list))
+          (ffir-default-find-file file-list))
       ;; fall back on regular find-file when no repository can be found
-      (let ((find-file (ffir-when-ido 'ido-find-file 'find-file)))
-        (command-execute find-file)))))
+      (command-execute (ffir-default-find-file-command)))))
 
 ;;;###autoload
 (defalias 'ffir 'find-file-in-repository)


### PR DESCRIPTION
The default behaviour is preserved (use `ido` when available otherwise use `find-file`).
Though a new variable was introduced: `ffir-completion` which can be `nil` (default, the old behavior), `'find-file`, `'ido` or `'ivy` so user now can enforce specific completion method if desired.

ivy completion provides fallback `C-x C-f`, `C-x f` bindings the same way as `ido`. If called outside of the project ivy fallbacks to `ido-find-file` (or `find-file`) as ivy doesn't provide a complementary function for `find-file` (counsel provides ivy completion with `counsel-find-file` though it's a different package).