### PR TITLE
Fix #22: --recurse-submodules incompatible with -o

### DIFF
--- a/find-file-in-repository.el
+++ b/find-file-in-repository.el
@@ -127,7 +127,7 @@
 (defvar ffir-repository-types
   `((".git"   . ,(lambda (dir)
                    (ffir-shell-command
-                    "git ls-files --recurse-submodules -zco --exclude-standard"     "\0" dir)))
+                    "git ls-files --recurse-submodules -zc --exclude-standard"      "\0" dir)))
     (".hg"    . ,(lambda (dir)
                    (ffir-shell-command "hg locate -0"                               "\0" dir)))
     ("_darcs" . ,(lambda (dir)


### PR DESCRIPTION
In a71a3eedf58158da675a6419d715ee24c2e116f1 --recurse-submodules was
added. It can't be used with the existing -o flag.

Removed -o to be more consistent with existing commands. For example,
`hg locate -0` does not list untracked files.